### PR TITLE
Remove getCustomer and getAccountsEnabled method in Account

### DIFF
--- a/src/main/java/jp/pay/model/Account.java
+++ b/src/main/java/jp/pay/model/Account.java
@@ -36,9 +36,7 @@ import jp.pay.net.RequestOptions;
 
 public class Account extends APIResource {
 	String id;
-	List<String> accountsEnabled;
 	Long created;
-	Customer customer;
 	String email;
 	Merchant merchant;
 
@@ -46,16 +44,8 @@ public class Account extends APIResource {
 		return id;
 	}
 
-	public List<String> getAccountsEnabled() {
-		return accountsEnabled;
-	}
-
 	public Long getCreated() {
 		return created;
-	}
-
-	public Customer getCustomer() {
-		return customer;
 	}
 
 	public String getEmail() {

--- a/src/test/java/jp/pay/model/AccountTest.java
+++ b/src/test/java/jp/pay/model/AccountTest.java
@@ -61,53 +61,8 @@ public class AccountTest extends BasePayjpTest {
 
         assertEquals("acct_8a27db83a7bf11a0c12b0c2833f", acc.getId());
 
-        LinkedList<String> ae = new LinkedList<String>();
-        ae.add("merchant");
-        ae.add("customer");
-        assertEquals(ae, acc.getAccountsEnabled());
-
         Long created = 1432965397l;
         assertEquals(created, acc.getCreated());
-
-        Integer customer_count = 1;
-        assertEquals(customer_count, acc.getCustomer().getCards().count);
-
-		List<Card> customerCards = acc.getCustomer().getCards().getData();
-		assertEquals(1, customerCards.size());
-		assertEquals("\u8d64\u5742", customerCards.get(0).getAddressCity());
-		assertEquals("7-4", customerCards.get(0).getAddressLine1());
-		assertEquals("203", customerCards.get(0).getAddressLine2());
-		assertEquals("\u6e2f\u533a", customerCards.get(0).getAddressState());
-		assertEquals("1070050", customerCards.get(0).getAddressZip());
-		assertEquals("passed", customerCards.get(0).getAddressZipCheck());
-		assertEquals("Visa", customerCards.get(0).getBrand());
-
-		Long card_created = 1432965397l;
-		assertEquals(card_created, customerCards.get(0).getCreated());
-
-		assertEquals("passed", customerCards.get(0).getCvcCheck());
-
-		Integer ex_m = 12;
-		assertEquals(ex_m, customerCards.get(0).getExpMonth());
-
-		Integer ex_y = 2016;
-		assertEquals(ex_y, customerCards.get(0).getExpYear());
-
-		assertEquals("e1d8225886e3a7211127df751c86787f", customerCards.get(0).getFingerprint());
-		assertEquals("car_99abf74cb5527ff68233a8b836dd", customerCards.get(0).getId());
-		assertEquals("4242", customerCards.get(0).getLast4());
-		assertEquals(true, customerCards.get(0).getLivemode());
-		assertEquals("Test Holder", customerCards.get(0).getName());
-
-		assertEquals("/v1/accounts/cards", acc.getCustomer().getCards().getURL());
-
-		Long customer_created = 1432965397l;
-		assertEquals(customer_created, acc.getCustomer().getCreated());
-
-		assertEquals(null, acc.getCustomer().getDefaultCard());
-		assertEquals("user customer", acc.getCustomer().getDescription());
-		assertEquals(null, acc.getCustomer().getEmail());
-		assertEquals("acct_cus_38153121efdb7964dd1e147", acc.getCustomer().getId());
 
         assertEquals(false, acc.getMerchant().getBankEnabled());
 

--- a/src/test/resources/jp/pay/model/account.json
+++ b/src/test/resources/jp/pay/model/account.json
@@ -1,38 +1,5 @@
 {
   "created": 1432965397,
-  "customer": {
-    "cards": {
-      "count": 1,
-      "data": [
-        {
-          "address_city": "\u8d64\u5742",
-          "address_line1": "7-4",
-          "address_line2": "203",
-          "address_state": "\u6e2f\u533a",
-          "address_zip": "1070050",
-          "address_zip_check": "passed",
-          "brand": "Visa",
-          "country": "JP",
-          "created": 1432965397,
-          "cvc_check": "passed",
-          "exp_month": 12,
-          "exp_year": 2016,
-          "fingerprint": "e1d8225886e3a7211127df751c86787f",
-          "id": "car_99abf74cb5527ff68233a8b836dd",
-          "last4": "4242",
-          "livemode": true,
-          "name": "Test Holder",
-          "object": "card"
-        }
-      ],
-      "object": "list",
-      "url": "/v1/accounts/cards"
-    },
-    "created": 1432965397,
-    "email": null,
-    "id": "acct_cus_38153121efdb7964dd1e147",
-    "object": "customer"
-  },
   "email": "firstuser@mail.com",
   "id": "acct_8a27db83a7bf11a0c12b0c2833f",
   "merchant": {

--- a/src/test/resources/jp/pay/model/account.json
+++ b/src/test/resources/jp/pay/model/account.json
@@ -1,8 +1,4 @@
 {
-  "accounts_enabled": [
-    "merchant",
-    "customer"
-  ],
   "created": 1432965397,
   "customer": {
     "cards": {
@@ -33,8 +29,6 @@
       "url": "/v1/accounts/cards"
     },
     "created": 1432965397,
-    "default_card": null,
-    "description": "user customer",
     "email": null,
     "id": "acct_cus_38153121efdb7964dd1e147",
     "object": "customer"


### PR DESCRIPTION
We're planning to change accounts API response, so
- Delete `Account.getCustommer` method
- Delete `Account.getAccountsEnabled` method ( `account.accounts_enabled` is already not provided )
