### PR TITLE
Add oraclejdk9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,12 @@
 language: java
 
 jdk:
-  - openjdk6
+  # https://github.com/travis-ci/travis-ci/issues/8199
+  # - openjdk6
   - openjdk7
-  - oraclejdk7
+  # https://github.com/travis-ci/travis-ci/issues/7884
+  #- oraclejdk7
+  - openjdk8
   - oraclejdk8
   - oraclejdk9
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ jdk:
   - openjdk7
   - oraclejdk7
   - oraclejdk8
+  - oraclejdk9
 
 sudo: false
 

--- a/pom.xml
+++ b/pom.xml
@@ -13,6 +13,11 @@
             <version>2.2.4</version>
         </dependency>
         <dependency>
+            <groupId>javax.xml.bind</groupId>
+            <artifactId>jaxb-api</artifactId>
+            <version>2.3.0</version>
+        </dependency>
+        <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
             <version>18.0</version>


### PR DESCRIPTION
I added oraclejdk9.
Travis CI removed in the following environment. See https://github.com/travis-ci/travis-ci/issues/7884 and https://github.com/travis-ci/travis-ci/issues/8199 for more details, please.
- openjdk6
- oraclejdk7