### PR TITLE
next_cycle_plan対応と非通過対応

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ If you're planning on using ProGuard, make sure that you exclude the Payjp bindi
 Usage
 =====
 
+In advance, you need to get token by [Checkout](https://pay.jp/docs/checkout).
+
 PayjpExample.java
 
 ```java
@@ -65,16 +67,12 @@ public class PayjpExample {
         Map<String, Object> chargeMap = new HashMap<String, Object>();
         chargeMap.put("amount", 3500);
         chargeMap.put("currency", "jpy");
-        Map<String, Object> cardMap = new HashMap<String, Object>();
-        cardMap.put("number", "4242424242424242");
-        cardMap.put("exp_month", 12);
-        cardMap.put("exp_year", 2020);
-        chargeMap.put("card", cardMap);
+        chargeMap.put("card", "your_token_id");
         try {
-            Charge charge = Charge.create(chargeMap
-);
+            Charge charge = Charge.create(chargeMap);
             System.out.println(charge);
         } catch (PayjpException e) {
+            System.out.println(e.message);
             e.printStackTrace();
         }
     }

--- a/RequestExample.md
+++ b/RequestExample.md
@@ -228,8 +228,9 @@
 
 	Map<String, Object> updateParams = new HashMap<String, Object>();
 	updateParams.put("plan", "pln_68e6a67f582462c223ca693bc549");
+	updateParams.put("next_cycle_plan", null); // null -> empty string
 	
-	su.update(updateParams);
+	su = su.update(updateParams);
 
 ###post定期購入を停止
 

--- a/RequestExample.md
+++ b/RequestExample.md
@@ -7,15 +7,9 @@
 
 	Payjp.apiKey = "sk_test_c62fade9d045b54cd76d7036";
 	
-	Map<String, Object> cardParams = new HashMap<String, Object>();
-	
-	cardParams.put("number", "4242424242424242");
-	cardParams.put("exp_year", "2020");
-	cardParams.put("exp_month", "02");
-	
 	Map<String, Object> chargeParams = new HashMap<String, Object>();
 
-	chargeParams.put("card", cardParams);
+	chargeParams.put("card", "your_token");
 	chargeParams.put("amount", 3500);
 	chargeParams.put("currency", "jpy");
 	
@@ -102,20 +96,6 @@
 	customerParams.put("offset", 10);
 	
 	Customer.all(customerParams);
-
-###post顧客のカードを作成
-
-	Payjp.apiKey = "sk_test_c62fade9d045b54cd76d7036";
-	
-	Customer cu = Customer.retrieve("cus_4df4b5ed720933f4fb9e28857517");
-	
-	Map<String, Object> cardParams = new HashMap<String, Object>();
-	
-	cardParams.put("number", "4242424242424242");
-	cardParams.put("exp_year", "2020");
-	cardParams.put("exp_month", "02");
-	
-	cu.createCard(cardParams);
 
 ###get顧客のカード情報を取得
 
@@ -289,21 +269,6 @@
 	Subscription.all(listParams);
 
 ##トークン (TOKENS)
-
-###postトークンを作成
-
-	Payjp.apiKey = "sk_test_c62fade9d045b54cd76d7036";
-	
-	Map<String, Object> tokenParams = new HashMap<String, Object>();
-	Map<String, Object> cardParams = new HashMap<String, Object>();
-	cardParams.put("number", "4242424242424242");
-	cardParams.put("exp_month", "02");
-	cardParams.put("exp_year", "2020");
-	cardParams.put("cvc", "314");
-	tokenParams.put("card", cardParams);
-	
-	Token.create(tokenParams);
-
 ###getトークン情報を取得
 
 	Payjp.apiKey = "sk_test_c62fade9d045b54cd76d7036";

--- a/src/main/java/jp/pay/model/Subscription.java
+++ b/src/main/java/jp/pay/model/Subscription.java
@@ -45,6 +45,7 @@ public class Subscription extends APIResource implements MetadataStore<Subscript
 	Boolean livemode;
 	Long pausedAt;
 	Plan plan;
+	Plan nextCyclePlan;
 	Long resumedAt;
 	Long start;
 	String status;
@@ -228,8 +229,14 @@ public class Subscription extends APIResource implements MetadataStore<Subscript
 	public Plan getPlan() {
 		return plan;
 	}
+	public Plan getNextCyclePlan() {
+		return this.nextCyclePlan;
+	}
 	public void setPlan(Plan plan) {
 		this.plan = plan;
+	}
+	public void setNextCyclePlan(Plan plan) {
+		this.nextCyclePlan = plan;
 	}
 	public Long getCanceledAt() {
 		return canceledAt;

--- a/src/test/java/jp/pay/PayjpScenarioTest.java
+++ b/src/test/java/jp/pay/PayjpScenarioTest.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2019 Pay, Inc. (https://pay.jp/)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ */
+package jp.pay;
+
+
+import jp.pay.exception.PayjpException;
+import jp.pay.model.*;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.Ignore;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.Assert.*;
+
+public class PayjpScenarioTest extends BasePayjpTest {
+	@BeforeClass
+	public static void setUp() {
+		Payjp.apiKey = "sk_test_c62fade9d045b54cd76d7036";	// public api key for test
+	}
+
+	@Ignore
+	@Test
+	public void testNextCyclePlanUpdate() throws PayjpException {
+		Map<String, Object> ListParams = new HashMap<String, Object>();
+		ListParams.put("limit", 1);
+	    SubscriptionCollection subscriptions = Subscription.all(ListParams);
+		assertEquals(1, (long) subscriptions.getCount());
+
+	    Subscription su = subscriptions.getData().get(0);
+		System.out.print(su.getId());
+		Map<String, Object> PlanParams = new HashMap<String, Object>();
+		PlanParams.put("amount", 1000);
+		PlanParams.put("currency", "jpy");
+		PlanParams.put("interval", "month");
+        Plan plan = Plan.create(PlanParams);
+        System.out.print(plan.getId());
+		Map<String, Object> subscriptionParams = new HashMap<String, Object>();
+		subscriptionParams.put("next_cycle_plan", plan.getId());
+		su = su.update(subscriptionParams);
+		assertEquals(plan.getId(), su.getNextCyclePlan().getId());
+
+		subscriptionParams.put("next_cycle_plan", null);
+		su = su.update(subscriptionParams);
+		assertEquals(null, su.getNextCyclePlan());
+		plan.delete();
+	}
+}


### PR DESCRIPTION
# abstract

- 新パラメータ[next_cycle_plan](https://pay.jp/docs/api/#%E5%AE%9A%E6%9C%9F%E8%AA%B2%E9%87%91%E3%82%92%E6%9B%B4%E6%96%B0)への対応
- 非通過対応よりカード作成周りのサンプルを削除

# check

- [x] pass `mvn test`
- [x] pass scenario test on local