### PR TITLE
fix Travis CI build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,13 @@
 language: java
 
+addons:
+  apt:
+    packages:
+      - openjdk-6-jdk
+      - openjdk-7-jdk
+
 jdk:
-  # https://github.com/travis-ci/travis-ci/issues/8199
-  # - openjdk6
+  - openjdk6
   - openjdk7
   # https://github.com/travis-ci/travis-ci/issues/7884
   #- oraclejdk7

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,11 @@
 language: java
 
+dist: trusty
+
 addons:
   apt:
     packages:
       - openjdk-6-jdk
-      - openjdk-7-jdk
 
 jdk:
   - openjdk6

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,13 +2,9 @@ language: java
 
 dist: trusty
 
-addons:
-  apt:
-    packages:
-      - openjdk-6-jdk
-
 jdk:
-  - openjdk6
+  # https://github.com/travis-ci/travis-ci/issues/8199
+  # - openjdk6
   - openjdk7
   # https://github.com/travis-ci/travis-ci/issues/7884
   #- oraclejdk7


### PR DESCRIPTION
- Travis CI build failed because default Virtualization environments changed.
  https://travis-ci.org/payjp/payjp-java/builds/633634678
  ref: 
  https://blog.travis-ci.com/2019-04-15-xenial-default-build-environment
  https://docs.travis-ci.com/user/reference/overview/
  https://docs.travis-ci.com/user/reference/xenial/#jvm-clojure-groovy-java-scala-support
  https://docs.travis-ci.com/user/reference/trusty/#jvm-clojure-groovy-java-scala-images
  
- use `Ubuntu Trusty 14.04`