### PR TITLE
リリースCI化

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,18 +7,25 @@ on:
 jobs:
   deploy:
     runs-on: ubuntu-latest
-    environment: Maven
     steps:
       - uses: actions/checkout@v3
+      - name: set fake tty  # https://github.com/actions/runner/issues/241
+        shell: 'script -q -e -c "bash {0}"'
+        run: |
+          export GPG_TTY=$(tty)
       - name: Set up Apache Maven Central
         uses: actions/setup-java@v3
         with:
           distribution: 'adopt'
           java-version: '11'
           server-id: maven
-          server-username: ${{ secrets.MAVEN_USERNAME }}
-          server-password: ${{ secrets.MAVEN_CENTRAL_TOKEN }}
+          server-username: MAVEN_USERNAME
+          server-password: MAVEN_CENTRAL_TOKEN
           gpg-private-key: ${{ secrets.MAVEN_GPG_PRIVATE_KEY }}
-          gpg-passphrase: ${{ secrets.MAVEN_GPG_PASSPHRASE }}
+          gpg-passphrase: MAVEN_GPG_PASSPHRASE
       - name: Publish to Apache Maven Central
         run: mvn clean deploy -DperformRelease=true
+        env:
+          MAVEN_USERNAME: ${{ secrets.MAVEN_USERNAME }}
+          MAVEN_CENTRAL_TOKEN: ${{ secrets.MAVEN_CENTRAL_TOKEN }}
+          MAVEN_GPG_PASSPHRASE: ${{ secrets.MAVEN_GPG_PASSPHRASE }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,24 @@
+name: build
+
+on:
+  release:
+    types: ['published']
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Apache Maven Central
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'adopt'
+          java-version: '11'
+          server-id: maven
+          server-username: ${{ secrets.MAVEN_USERNAME }}
+          server-password: ${{ secrets.MAVEN_CENTRAL_TOKEN }}
+          gpg-private-key: ${{ secrets.MAVEN_GPG_PRIVATE_KEY }}
+          gpg-passphrase: ${{ secrets.MAVEN_GPG_PASSPHRASE }}
+
+      - name: Publish to Apache Maven Central
+        run: mvn clean deploy -DperformRelease=true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,7 @@ on:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    environment: Maven
     steps:
       - uses: actions/checkout@v3
       - name: Set up Apache Maven Central
@@ -19,6 +20,5 @@ jobs:
           server-password: ${{ secrets.MAVEN_CENTRAL_TOKEN }}
           gpg-private-key: ${{ secrets.MAVEN_GPG_PRIVATE_KEY }}
           gpg-passphrase: ${{ secrets.MAVEN_GPG_PASSPHRASE }}
-
       - name: Publish to Apache Maven Central
         run: mvn clean deploy -DperformRelease=true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
           gpg-private-key: ${{ secrets.MAVEN_GPG_PRIVATE_KEY }}
           gpg-passphrase: MAVEN_GPG_PASSPHRASE
       - name: Publish to Apache Maven Central
-        run: mvn clean deploy -DperformRelease=true
+        run: mvn deploy
         env:
           MAVEN_USERNAME: ${{ secrets.MAVEN_USERNAME }}
           MAVEN_CENTRAL_TOKEN: ${{ secrets.MAVEN_CENTRAL_TOKEN }}

--- a/pom.xml
+++ b/pom.xml
@@ -64,7 +64,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-gpg-plugin</artifactId>
-                <version>1.5</version>
+                <version>1.6</version>
                 <executions>
                     <execution>
                         <id>sign-artifacts</id>


### PR DESCRIPTION
- リリースジョブを追加
  - https://github.com/actions/setup-java/blob/main/docs/advanced-usage.md#Publishing-using-Apache-Maven
    のSet up Apache Maven Central以下を参考
- レポジトリのReleaseが作られたら実行される
- 動作確認 https://github.com/payjp/payjp-java/runs/8242820066?check_suite_focus=true
- https://github.com/payjp/payjp-java/pull/33 が必要だったので取り込んだ
- 必要そうだったのでgpg pluginのバージョンを上げた
- 必要な変数はレポジトリシークレットに入れた