### PR TITLE
3Dセキュア対応

### DIFF
--- a/src/main/java/jp/pay/model/Charge.java
+++ b/src/main/java/jp/pay/model/Charge.java
@@ -54,6 +54,7 @@ public class Charge extends APIResource implements MetadataStore<Charge> {
 	String subscription;
 	Map<String, String> metadata = new HashMap<String, String>();
 	String feeRate;
+	String threeDSecureStatus;
 
 	public String getId() {
 		return id;
@@ -211,6 +212,15 @@ public class Charge extends APIResource implements MetadataStore<Charge> {
 	public void setFeeRate(String feeRate) {
 		this.feeRate = feeRate;
 	}
+
+	public String getThreeDSecureStatus() {
+		return threeDSecureStatus;
+	}
+
+	public void setThreeDSecureStatus(String threeDSecureStatus) {
+		this.threeDSecureStatus = threeDSecureStatus;
+	}
+
 
 	public static Charge create(Map<String, Object> params)
 			throws AuthenticationException, InvalidRequestException,

--- a/src/main/java/jp/pay/model/Charge.java
+++ b/src/main/java/jp/pay/model/Charge.java
@@ -319,4 +319,17 @@ public class Charge extends APIResource implements MetadataStore<Charge> {
 		return request(RequestMethod.POST, String.format("%s/capture",
 						instanceURL(Charge.class, this.getId())), params, Charge.class, options);
 	}
+
+	public Charge tdsFinish(Map<String, Object> params, RequestOptions options)
+			throws AuthenticationException, InvalidRequestException,
+			APIConnectionException, CardException, APIException {
+		return request(RequestMethod.POST, String.format("%s/tds_finish", instanceURL(Charge.class, this.getId())), params, Charge.class, options);
+	}
+
+	public static Charge tdsFinish(String id)
+		throws AuthenticationException, InvalidRequestException,
+		APIConnectionException, CardException, APIException {
+		return request(RequestMethod.POST, String.format("%s/tds_finish", instanceURL(Charge.class, id)), null, Charge.class, null);
+	}
+
 }

--- a/src/main/java/jp/pay/model/Charge.java
+++ b/src/main/java/jp/pay/model/Charge.java
@@ -320,16 +320,9 @@ public class Charge extends APIResource implements MetadataStore<Charge> {
 						instanceURL(Charge.class, this.getId())), params, Charge.class, options);
 	}
 
-	public Charge tdsFinish(Map<String, Object> params, RequestOptions options)
-			throws AuthenticationException, InvalidRequestException,
-			APIConnectionException, CardException, APIException {
-		return request(RequestMethod.POST, String.format("%s/tds_finish", instanceURL(Charge.class, this.getId())), params, Charge.class, options);
-	}
-
-	public static Charge tdsFinish(String id, RequestOptions options)
+	public static Charge tdsFinish(String id, Map<String, Object> params, RequestOptions options)
 		throws AuthenticationException, InvalidRequestException,
 		APIConnectionException, CardException, APIException {
-		return request(RequestMethod.POST, String.format("%s/tds_finish", instanceURL(Charge.class, id)), null, Charge.class, options);
+		return request(RequestMethod.POST, String.format("%s/tds_finish", instanceURL(Charge.class, id)), params, Charge.class, options);
 	}
-
 }

--- a/src/main/java/jp/pay/model/Charge.java
+++ b/src/main/java/jp/pay/model/Charge.java
@@ -326,10 +326,10 @@ public class Charge extends APIResource implements MetadataStore<Charge> {
 		return request(RequestMethod.POST, String.format("%s/tds_finish", instanceURL(Charge.class, this.getId())), params, Charge.class, options);
 	}
 
-	public static Charge tdsFinish(String id)
+	public static Charge tdsFinish(String id, RequestOptions options)
 		throws AuthenticationException, InvalidRequestException,
 		APIConnectionException, CardException, APIException {
-		return request(RequestMethod.POST, String.format("%s/tds_finish", instanceURL(Charge.class, id)), null, Charge.class, null);
+		return request(RequestMethod.POST, String.format("%s/tds_finish", instanceURL(Charge.class, id)), null, Charge.class, options);
 	}
 
 }

--- a/src/test/java/jp/pay/model/ChargeTest.java
+++ b/src/test/java/jp/pay/model/ChargeTest.java
@@ -45,65 +45,65 @@ import static org.junit.Assert.assertNull;
 import static org.mockito.Mockito.*;
 
 public class ChargeTest extends BasePayjpTest {
-    @Before
-    public void mockPayjpResponseGetter() {
-        APIResource.setPayjpResponseGetter(networkMock);
-    }
+	@Before
+	public void mockPayjpResponseGetter() {
+		APIResource.setPayjpResponseGetter(networkMock);
+	}
 
-    @After
-    public void unmockPayjpResponseGetter() {
-        /* This needs to be done because tests aren't isolated in Java */
-        APIResource.setPayjpResponseGetter(new LivePayjpResponseGetter());
-    }
+	@After
+	public void unmockPayjpResponseGetter() {
+		/* This needs to be done because tests aren't isolated in Java */
+		APIResource.setPayjpResponseGetter(new LivePayjpResponseGetter());
+	}
 
-    @Test
-    public void testDeserialize() throws PayjpException, IOException {
-        String json = resource("charge.json");
-        
-        Charge ch = APIResource.GSON.fromJson(json, Charge.class);
+	@Test
+	public void testDeserialize() throws PayjpException, IOException {
+		String json = resource("charge.json");
+		
+		Charge ch = APIResource.GSON.fromJson(json, Charge.class);
 
-        assertEquals("ch_fa990a4c10672a93053a774730b0a", ch.getId());
-        assertEquals(3500, (int) ch.getAmount());
+		assertEquals("ch_fa990a4c10672a93053a774730b0a", ch.getId());
+		assertEquals(3500, (int) ch.getAmount());
 
-        Long created = 1578372537l;
+		Long created = 1578372537l;
 
-        assertEquals(created, ch.getCreated());
-        assertEquals("jpy", ch.getCurrency());
-        assertFalse(ch.getLivemode());
-        assertTrue(ch.getPaid());
-        assertFalse(ch.getRefunded());
-        assertTrue(ch.getCaptured());
-        assertEquals("test charge", ch.getDescription());
-        assertNull(ch.getFailureMessage());
-        assertNull(ch.getFailureCode());
-        assertEquals(0, (int) ch.getAmountRefunded());
-        assertNull(ch.getCustomer());
-        assertNull(ch.getExpiredAt());
-        assertNull(ch.getRefundReason());
-        assertNull(ch.getSubscription());
-        assertNull(ch.getMetadata());
-        assertEquals("3.00", ch.getFeeRate());
+		assertEquals(created, ch.getCreated());
+		assertEquals("jpy", ch.getCurrency());
+		assertFalse(ch.getLivemode());
+		assertTrue(ch.getPaid());
+		assertFalse(ch.getRefunded());
+		assertTrue(ch.getCaptured());
+		assertEquals("test charge", ch.getDescription());
+		assertNull(ch.getFailureMessage());
+		assertNull(ch.getFailureCode());
+		assertEquals(0, (int) ch.getAmountRefunded());
+		assertNull(ch.getCustomer());
+		assertNull(ch.getExpiredAt());
+		assertNull(ch.getRefundReason());
+		assertNull(ch.getSubscription());
+		assertNull(ch.getMetadata());
+		assertEquals("3.00", ch.getFeeRate());
 		assertEquals("attempt", ch.getThreeDSecureStatus());
 
-        Card ca = ch.getCard();
-        assertEquals("car_d0e44730f83b0a19ba6caee04160", ca.getId());
-        assertEquals("Visa", ca.getBrand());
-        assertEquals(created, ca.getCreated());
-        assertNull(ca.getLivemode());
-        assertEquals(2, (int) ca.getExpMonth());
-        assertEquals(2020, (int) ca.getExpYear());
-        assertEquals("4242", ca.getLast4());
-        assertNull(ca.getCountry());
-        assertNull(ca.getName());
-        assertNull(ca.getAddressLine1());
-        assertNull(ca.getAddressLine2());
-        assertNull(ca.getAddressCity());
-        assertNull(ca.getAddressZip());
-        assertNull(ca.getAddressState());
-        assertEquals("unchecked", ca.getAddressZipCheck());
-        assertEquals("unchecked", ca.getCvcCheck());
-        assertEquals("e1d8225886e3a7211127df751c86787f", ca.getFingerprint());
-        
-        assertEquals("Visa", ca.getBrand());
-    }
+		Card ca = ch.getCard();
+		assertEquals("car_d0e44730f83b0a19ba6caee04160", ca.getId());
+		assertEquals("Visa", ca.getBrand());
+		assertEquals(created, ca.getCreated());
+		assertNull(ca.getLivemode());
+		assertEquals(2, (int) ca.getExpMonth());
+		assertEquals(2020, (int) ca.getExpYear());
+		assertEquals("4242", ca.getLast4());
+		assertNull(ca.getCountry());
+		assertNull(ca.getName());
+		assertNull(ca.getAddressLine1());
+		assertNull(ca.getAddressLine2());
+		assertNull(ca.getAddressCity());
+		assertNull(ca.getAddressZip());
+		assertNull(ca.getAddressState());
+		assertEquals("unchecked", ca.getAddressZipCheck());
+		assertEquals("unchecked", ca.getCvcCheck());
+		assertEquals("e1d8225886e3a7211127df751c86787f", ca.getFingerprint());
+		
+		assertEquals("Visa", ca.getBrand());
+	}
 }

--- a/src/test/java/jp/pay/model/ChargeTest.java
+++ b/src/test/java/jp/pay/model/ChargeTest.java
@@ -83,6 +83,7 @@ public class ChargeTest extends BasePayjpTest {
         assertNull(ch.getSubscription());
         assertNull(ch.getMetadata());
         assertEquals("3.00", ch.getFeeRate());
+		assertEquals("attempt", ch.getThreeDSecureStatus());
 
         Card ca = ch.getCard();
         assertEquals("car_d0e44730f83b0a19ba6caee04160", ca.getId());

--- a/src/test/resources/jp/pay/model/charge.json
+++ b/src/test/resources/jp/pay/model/charge.json
@@ -42,5 +42,6 @@
   "refunded": false,
   "subscription": null,
   "tenant": "ten_121673955bd7aa144de5a8f6c262",
-  "total_platform_fee": 350
+  "total_platform_fee": 350,
+  "three_d_secure_status": "attempt"
 }


### PR DESCRIPTION
- [3Dセキュア完了エンドポイント](https://pay.jp/docs/api/#3d%E3%82%BB%E3%82%AD%E3%83%A5%E3%82%A2%E3%83%95%E3%83%AD%E3%83%BC%E3%82%92%E5%AE%8C%E4%BA%86%E3%81%99%E3%82%8B)へのリクエストメソッドを追加
- [Chargeオブジェクト](https://pay.jp/docs/api/#charge%E3%82%AA%E3%83%96%E3%82%B8%E3%82%A7%E3%82%AF%E3%83%88)にthreeDSecureStatusプロパティ追加
- 使い方例:
  - `Charge.tdsFinish("ch_xxxxxxxxxx", null, null);`