### PR TITLE
feat: add token tds_finish.

### DIFF
--- a/src/main/java/jp/pay/model/Card.java
+++ b/src/main/java/jp/pay/model/Card.java
@@ -53,6 +53,7 @@ public class Card extends ExternalAccount implements MetadataStore<Card> {
 	Map<String, String> metadata = new HashMap<String, String>();
 	String email;
 	String phone;
+	String threeDSecureStatus;
 
 	public Card update(Map<String, Object> params)
             throws AuthenticationException, InvalidRequestException,
@@ -199,6 +200,10 @@ public class Card extends ExternalAccount implements MetadataStore<Card> {
 
 	public String getPhone() {
 		return phone;
+	}
+
+	public String getThreeDSecureStatus() {
+		return threeDSecureStatus;
 	}
 
 }

--- a/src/main/java/jp/pay/model/Token.java
+++ b/src/main/java/jp/pay/model/Token.java
@@ -112,4 +112,10 @@ public class Token extends APIResource {
 			APIConnectionException, CardException, APIException {
 		return request(RequestMethod.GET, instanceURL(Token.class, id), null, Token.class, options);
 	}
+
+	public static Token tdsFinish(String id, Map<String, Object> params, RequestOptions options)
+			throws AuthenticationException, InvalidRequestException,
+			APIConnectionException, CardException, APIException {
+		return request(RequestMethod.POST, String.format("%s/tds_finish", instanceURL(Token.class, id)), params, Token.class, options);
+	}
 }

--- a/src/test/java/jp/pay/PayjpTest.java
+++ b/src/test/java/jp/pay/PayjpTest.java
@@ -942,6 +942,7 @@ public class PayjpTest extends BasePayjpTest {
 		stubNetwork(Token.class, "{\"id\":\"tok_xxxxxxxxxxxxxxxxxxxxxxxx\"}");
 		Token token = Token.tdsFinish("tok_xxxxxxxxxxxxxxxxxxxxxxxx", null, null);
 		assertEquals("tok_xxxxxxxxxxxxxxxxxxxxxxxx", token.getId());
+		verifyPost(Token.class, "https://api.pay.jp/v1/tokens/tok_xxxxxxxxxxxxxxxxxxxxxxxx/tds_finish", null);
 	}
 
 	@Test

--- a/src/test/java/jp/pay/PayjpTest.java
+++ b/src/test/java/jp/pay/PayjpTest.java
@@ -938,6 +938,13 @@ public class PayjpTest extends BasePayjpTest {
 	}
 
 	@Test
+	public void testTokenTdsFinish() throws PayjpException {
+		stubNetwork(Token.class, "{\"id\":\"tok_xxxxxxxxxxxxxxxxxxxxxxxx\"}");
+		Token token = Token.tdsFinish("tok_xxxxxxxxxxxxxxxxxxxxxxxx", null, null);
+		assertEquals("tok_xxxxxxxxxxxxxxxxxxxxxxxx", token.getId());
+	}
+
+	@Test
 	public void testEventRetrieve() throws PayjpException {
 		Map<String, Object> listParams = new HashMap<String, Object>();
 		listParams.put("limit", 1);

--- a/src/test/java/jp/pay/model/ChargeTest.java
+++ b/src/test/java/jp/pay/model/ChargeTest.java
@@ -59,7 +59,7 @@ public class ChargeTest extends BasePayjpTest {
 	@Test
 	public void testDeserialize() throws PayjpException, IOException {
 		String json = resource("charge.json");
-		
+
 		Charge ch = APIResource.GSON.fromJson(json, Charge.class);
 
 		assertEquals("ch_fa990a4c10672a93053a774730b0a", ch.getId());
@@ -106,7 +106,8 @@ public class ChargeTest extends BasePayjpTest {
 		assertEquals("e1d8225886e3a7211127df751c86787f", ca.getFingerprint());
 		assertEquals("liveaccount@example.com", ca.getEmail());
 		assertEquals("+81301234567", ca.getPhone());
-		
+		assertNull(ca.getThreeDSecureStatus());
+
 		assertEquals("Visa", ca.getBrand());
 	}
 }

--- a/src/test/java/jp/pay/model/TokenTest.java
+++ b/src/test/java/jp/pay/model/TokenTest.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2010-2011 Stripe (http://stripe.com)
+ * Copyright (c) 2024 PAY, Inc. (http://pay.co.jp/)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ */
+package jp.pay.model;
+
+
+import jp.pay.net.APIResource;
+
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import jp.pay.exception.PayjpException;
+import jp.pay.BasePayjpTest;
+import static org.junit.Assert.assertEquals;
+
+public class TokenTest extends BasePayjpTest {
+	@Test
+	public void testDeserialize() throws PayjpException, IOException {
+		String json = resource("token.json");
+		Token token = APIResource.GSON.fromJson(json, Token.class);
+		assertEquals(Long.valueOf("1442290383"), token.getCreated());
+		assertEquals("tok_5ca06b51685e001723a2c3b4aeb4", token.getId());
+		assertEquals(Boolean.FALSE, token.getLivemode());
+		assertEquals(Boolean.FALSE, token.getUsed());
+		assertEquals("card", token.getCard().getObject());
+	}
+
+	@Test
+	public void testRetrieve() throws PayjpException {
+		stubNetwork(Token.class, "{\"id\":\"token1\"}");
+		Token token = Token.retrieve("token1");
+		verifyGet(Token.class, "https://api.pay.jp/v1/tokens/token1");
+		assertEquals(token.getId(), "token1");
+	}
+}

--- a/src/test/resources/jp/pay/model/charge.json
+++ b/src/test/resources/jp/pay/model/charge.json
@@ -23,7 +23,8 @@
     "name": "PAY TARO",
     "object": "card",
     "email": "liveaccount@example.com",
-    "phone": "+81301234567"
+    "phone": "+81301234567",
+    "three_d_secure_status": null
   },
   "created": 1578372537,
   "currency": "jpy",

--- a/src/test/resources/jp/pay/model/token.json
+++ b/src/test/resources/jp/pay/model/token.json
@@ -1,0 +1,32 @@
+{
+  "card": {
+    "address_city": null,
+    "address_line1": null,
+    "address_line2": null,
+    "address_state": null,
+    "address_zip": null,
+    "address_zip_check": "unchecked",
+    "brand": "Visa",
+    "country": null,
+    "created": 1442290383,
+    "customer": null,
+    "cvc_check": "passed",
+    "exp_month": 2,
+    "exp_year": 2024,
+    "fingerprint": "e1d8225886e3a7211127df751c86787f",
+    "id": "car_e3ccd4e0959f45e7c75bacc4be90",
+    "livemode": false,
+    "metadata": {},
+    "last4": "4242",
+    "name": "PAY TARO",
+    "object": "card",
+    "three_d_secure_status": "verified",
+    "email": "liveaccount@example.com",
+    "phone": "+81301234567"
+  },
+  "created": 1442290383,
+  "id": "tok_5ca06b51685e001723a2c3b4aeb4",
+  "livemode": false,
+  "object": "token",
+  "used": false
+}


### PR DESCRIPTION
## Overview

add token tds_finish.

* [トークンに対する3Dセキュアフローを完了する – PAY.JP API リファレンス](https://pay.jp/docs/api/#%E3%83%88%E3%83%BC%E3%82%AF%E3%83%B3%E3%81%AB%E5%AF%BE%E3%81%99%E3%82%8B3d%E3%82%BB%E3%82%AD%E3%83%A5%E3%82%A2%E3%83%95%E3%83%AD%E3%83%BC%E3%82%92%E5%AE%8C%E4%BA%86%E3%81%99%E3%82%8B)

## Changes

* add token tds_finish.
* add card three_d_secure_status param.
