### PR TITLE
fix: migrate Maven Central publishing from OSSRH to Central Portal

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,18 +7,20 @@ on:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
-      - uses: actions/checkout@v3
-      - name: set fake tty  # https://github.com/actions/runner/issues/241
+      - uses: actions/checkout@v4
+      - name: set fake tty
         shell: 'script -q -e -c "bash {0}"'
         run: |
           export GPG_TTY=$(tty)
       - name: Set up Apache Maven Central
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
-          distribution: 'adopt'
+          distribution: 'temurin'
           java-version: '11'
-          server-id: sonatype-nexus-staging
+          server-id: central
           server-username: MAVEN_USERNAME
           server-password: MAVEN_CENTRAL_TOKEN
           gpg-private-key: ${{ secrets.MAVEN_GPG_PRIVATE_KEY }}

--- a/pom.xml
+++ b/pom.xml
@@ -35,11 +35,22 @@
         <name>Payjp</name>
         <url>https://pay.jp</url>
     </organization>
-    <parent>
-        <groupId>org.sonatype.oss</groupId>
-        <artifactId>oss-parent</artifactId>
-        <version>7</version>
-    </parent>
+    <licenses>
+        <license>
+            <name>MIT License</name>
+            <url>https://opensource.org/licenses/MIT</url>
+            <distribution>repo</distribution>
+        </license>
+    </licenses>
+    <developers>
+        <developer>
+            <id>payjp</id>
+            <name>PAY.JP</name>
+            <email>support@pay.jp</email>
+            <organization>PAY, Inc.</organization>
+            <organizationUrl>https://pay.jp</organizationUrl>
+        </developer>
+    </developers>
     <scm>
         <connection>scm:git:git@github.com:payjp/payjp-java.git</connection>
         <developerConnection>scm:git:git@github.com:payjp/payjp-java.git</developerConnection>
@@ -121,22 +132,15 @@
                 </configuration>
             </plugin>
             <plugin>
-              <groupId>org.sonatype.plugins</groupId>
-              <version>1.6.4</version>
-              <artifactId>nexus-staging-maven-plugin</artifactId>
-              <executions>
-                <execution>
-                  <id>default-deploy</id>
-                  <phase>deploy</phase>
-                  <goals>
-                    <goal>deploy</goal>
-                  </goals>
-                </execution>
-              </executions>
-              <configuration>
-                <serverId>sonatype-nexus-staging</serverId>
-                <nexusUrl>https://oss.sonatype.org/</nexusUrl>
-              </configuration>
+                <groupId>org.sonatype.central</groupId>
+                <artifactId>central-publishing-maven-plugin</artifactId>
+                <version>0.10.0</version>
+                <extensions>true</extensions>
+                <configuration>
+                    <publishingServerId>central</publishingServerId>
+                    <autoPublish>true</autoPublish>
+                    <waitUntil>published</waitUntil>
+                </configuration>
             </plugin>
         </plugins>
     </build>


### PR DESCRIPTION
## Summary

旧 OSSRH (oss.sonatype.org) が廃止され `mvn deploy` が 402 Payment Required で失敗する問題を修正。新 Central Portal (central.sonatype.com) に移行。

## Changes

* `nexus-staging-maven-plugin` を `central-publishing-maven-plugin:0.10.0` に置換
* `oss-parent:7` の parent POM を削除
* Central Portal 必須メタデータ (`<licenses>`, `<developers>`) を追加
* release.yml: `server-id` を `central` に変更、actions を v4 に更新、`permissions` 追加

## Checklist

- [x] pom.xml の変更
- [x] release.yml の変更
- [x] GitHub Secrets の更新
- [x] Central Portal でネームスペース (jp.pay) の確認
- [x] リリース再実行で公開成功を確認

## その他

- 既存プラグイン (gpg, source, javadoc, compiler, surefire) は変更なし
- src/ 以下のソースコードは変更なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)